### PR TITLE
Bump Go version to 1.23.9

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.23.9'
     - name: Build
       run: go build -v ./...
     - name: Test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 wiggin77
+Copyright (c) 2018-Present wiggin77
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,5 @@ echo building OpenBSD...
 env GOOS=openbsd GOARCH=amd64 go build -o ./build/openbsd_amd64/mailrelay-openbsd-amd64
 
 # build Linux ARM64 (Raspberry PI)
-echo building Linux ARM64 (Raspberry PI)...
+echo "building Linux ARM64 (Raspberry PI)..."
 env GOOS=linux GOARCH=arm go build -o ./build/linux_amd64/mailrelay-linux-arm64

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,21 @@
 module github.com/wiggin77/mailrelay
 
-go 1.14
+go 1.23.8
+
+require (
+	github.com/flashmob/go-guerrilla v1.6.1
+	github.com/jpillora/ipfilter v1.2.2
+	github.com/pkg/errors v0.9.1
+)
 
 require (
 	github.com/asaskevich/EventBus v0.0.0-20180103000110-68a521d7cbbb // indirect
-	github.com/flashmob/go-guerrilla v1.6.1
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
-	github.com/jpillora/ipfilter v1.2.2
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/phuslu/iploc v1.0.20200807 // indirect
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce // indirect
 	golang.org/x/sys v0.1.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/asaskevich/EventBus v0.0.0-20180103000110-68a521d7cbbb h1:UgErHX+sTKfxJ1+2IksfX2Jeb2DcSgWN0oqRTUzSg74=
 github.com/asaskevich/EventBus v0.0.0-20180103000110-68a521d7cbbb/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -12,12 +11,6 @@ github.com/jpillora/ipfilter v1.2.2 h1:lfENG7V1/T+ZutAtSbt6gssvzj3Ql0JmcFlqS/BES
 github.com/jpillora/ipfilter v1.2.2/go.mod h1:xvAYjA+48eM9E5+sg9yI55N5lE9sefckjsnDvSiEA+g=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/phuslu/iploc v1.0.20200807 h1:LIBm2Y9l5zmUvnJhQgMcLZ0iVwuG+5/L6AgbMwSOpE4=
 github.com/phuslu/iploc v1.0.20200807/go.mod h1:Q/0VX0txvbxekt4NhWIi3Q3eyZ139lHhnlzvDxyXhuc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -37,8 +30,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/smtp"
@@ -67,7 +68,7 @@ func run() error {
 	flag.StringVar(&testsender, "sender", "", "used with 'test' to specify sender email address")
 	flag.StringVar(&testrcpt, "rcpt", "", "used with 'test' to specify recipient email address")
 	flag.BoolVar(&verbose, "verbose", false, "verbose output")
-	flag.BoolVar(&checkIP, "checkIP", false, "Checks a provided IP address to see if it would be allowed")
+	flag.BoolVar(&checkIP, "checkIP", false, "checks a provided IP address to see if it would be allowed")
 	flag.StringVar(&ipToCheck, "ip", "", "used with 'checkIP' to specify IP address to test")
 	flag.Parse()
 
@@ -129,7 +130,14 @@ func run() error {
 	}
 
 	if checkIP {
-		Logger.Infof("Checking to see if %s is allowed to send email: %t", ipToCheck, AllowedSendersFilter.Allowed(ipToCheck))
+		if ipToCheck == "" {
+			return errors.New("IP address to check is required when `checkIP` flag is used. Provide an IP address using the `-ip` flag")
+		}
+		result := ""
+		if !AllowedSendersFilter.Blocked(ipToCheck) {
+			result = "NOT "
+		}
+		fmt.Printf("IP address %s is %sallowed to send email\n", ipToCheck, result)
 		return nil
 	}
 


### PR DESCRIPTION
Bumps Go version to 1.23.9
- fixes syntax error in build script
